### PR TITLE
Add http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+.env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,15 +9,13 @@
     "**/node_modules": true
   },
   "conventionalCommits.scopes": [
-    // Dependencies
     "deps",
     "dev-deps",
     "peer-deps",
-
-    // Gelato API Scopes
     "orders",
     "products",
-    "shipment"
+    "shipment",
+    "http"
   ],
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [Gelato API Docs](https://dashboard.gelato.com/docs/) for more details.
 - [ ] Create and provide ability to initialize `GelatoClient` with options.
   - [ ] Get `apiKey` option from env variable
   - [ ] Provide `apiKey` in _options_ param when initializing the client.
-- [ ] Create custom HTTP client to make authenticated requests
+- [x] Create custom HTTP client to make authenticated requests
 
 ### APIs integration
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "16.11.7",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
+    "dotenv": "^16.0.3",
     "eslint": "~8.15.0",
     "eslint-config-prettier": "8.1.0",
     "jest": "28.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/ekkolon/gelato-node"
   },
   "dependencies": {
+    "axios": "^1.3.4",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/shared/http/.babelrc
+++ b/packages/shared/http/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/js/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/shared/http/.eslintrc.json
+++ b/packages/shared/http/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/shared/http/README.md
+++ b/packages/shared/http/README.md
@@ -1,0 +1,11 @@
+# Gelato Node.js Client - HTTP Client
+
+This library provides an HTTP client used for making (authenticated) requests to the Gelato API.
+
+## Running unit tests
+
+Run `nx test shared-http` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint shared-http` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/shared/http/jest.config.ts
+++ b/packages/shared/http/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'shared-http',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/packages/shared/http',
+};

--- a/packages/shared/http/package.json
+++ b/packages/shared/http/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@gelato/shared/http",
+  "version": "0.0.1"
+}

--- a/packages/shared/http/project.json
+++ b/packages/shared/http/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "shared-http",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/shared/http/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/shared/http",
+        "tsConfig": "packages/shared/http/tsconfig.lib.json",
+        "packageJson": "packages/shared/http/package.json",
+        "main": "packages/shared/http/src/index.ts",
+        "assets": ["packages/shared/http/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/shared/http/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/shared/http/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": ["shared"]
+}

--- a/packages/shared/http/src/index.ts
+++ b/packages/shared/http/src/index.ts
@@ -1,0 +1,18 @@
+/*!
+ * @license
+ * Copyright 2023 Nelson Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './lib/http';

--- a/packages/shared/http/src/lib/http.spec.ts
+++ b/packages/shared/http/src/lib/http.spec.ts
@@ -1,0 +1,7 @@
+import { http } from './http';
+
+describe('http', () => {
+  it('should work', () => {
+    expect(http()).toEqual('http');
+  });
+});

--- a/packages/shared/http/src/lib/http.ts
+++ b/packages/shared/http/src/lib/http.ts
@@ -15,6 +15,115 @@
  * limitations under the License.
  */
 
-export function http(): string {
-  return 'http';
+import axios, { AxiosRequestConfig, RawAxiosRequestHeaders } from 'axios';
+
+export const API_KEY_HEADER = 'X-API-KEY';
+export const API_KEY_ENV_VARIABLE = 'GELATO_API_KEY';
+
+/**
+ * Options to customize how a Gelato {@link HttpClient} processes requests.
+ *
+ * @publicApi
+ */
+export interface HttpClientOptions {
+  apiKey?: string;
+}
+
+/**
+ * HTTP client for making (authenticated) requests to Gelato APIs.
+ *
+ * @remarks
+ * All requests to Gelato APIs must include an `X-API-KEY` header.
+ *
+ * You can provide this value in the following ways:
+ *
+ * - Using the `apiKey` option when initializing the client.
+ * - Using an `GELATO_API_KEY` environment variable (recommended).
+ *
+ *    Make sure the current node process contains this variable,
+ *    either by directly assigning it when running your server process
+ *    or by using a _.env_ file and loading it before starting the process.
+ *
+ * @todo Improve response object - provide more context, like statusCode, url.
+ *
+ * @publicApi
+ */
+export class HttpClient {
+  constructor(private readonly options: HttpClientOptions) {}
+
+  /**
+   * Make a `GET` request to an eligable Gelato API endpoint.
+   * @param url Resource URL to fetch.
+   * @param options Options to customize the request.
+   * @returns
+   */
+  async get<T>(url: string, options: AxiosRequestConfig = {}): Promise<T> {
+    const response = await axios.get<T>(url, this._mergeRequestConfig(options));
+
+    return response.data;
+  }
+
+  /**
+   * Make a `POST` request to an eligable Gelato API endpoint.
+   * @param url Target url to request data from.
+   * @param options Options to customize the request.
+   */
+  async post<T, D>(
+    url: string,
+    data: D,
+    options: Omit<AxiosRequestConfig<D>, 'data'> = {},
+  ): Promise<T> {
+    const response = await axios.post<T>(url, data, this._mergeRequestConfig(options));
+
+    return response.data;
+  }
+  /**
+   * Make a `PATCH` request to an eligable Gelato API endpoint.
+   * @param url Resource URL to patch.
+   * @param options Options to customize the request.
+   */
+  async patch<T, D>(url: string, data: D, options: Omit<AxiosRequestConfig<D>, 'data'> = {}) {
+    const response = await axios.patch<T>(url, data, this._mergeRequestConfig(options));
+
+    return response.data;
+  }
+  /**
+   * Make a `DELETE` request to an eligable Gelato API endpoint.
+   * @param url Resource URL to delete.
+   * @param options Options to customize the request.
+   */
+  async delete<T = any>(url: string, options: Omit<AxiosRequestConfig, 'data'> = {}) {
+    const response = await axios.delete<T>(url, this._mergeRequestConfig(options));
+
+    return response.data;
+  }
+
+  private _mergeRequestConfig(options: AxiosRequestConfig) {
+    const { headers, ...requestOptions } = options;
+    return { ...requestOptions, headers: this._mergeRequestHeaders(headers) };
+  }
+
+  private _mergeRequestHeaders(
+    axiosHeaders: AxiosRequestConfig['headers'],
+  ): RawAxiosRequestHeaders {
+    return { ...axiosHeaders, 'Content-Type': 'application/json', ...this._getAuthHeader() };
+  }
+
+  private _getAuthHeader() {
+    const apikKey = this.getApiKey();
+    return { [API_KEY_HEADER]: apikKey };
+  }
+
+  private getApiKey(): string {
+    const apiKey = this.options?.apiKey ?? process.env[API_KEY_ENV_VARIABLE];
+    if (!this.checkApiKeyValue(apiKey)) {
+      throw new Error(`Requests to the Gelato API must use an '${API_KEY_HEADER}' header.`);
+    }
+
+    return apiKey;
+  }
+
+  private checkApiKeyValue(apiKey: unknown): apiKey is string {
+    return apiKey != null && typeof apiKey === 'string' && apiKey.length > 0;
+  }
 }

--- a/packages/shared/http/src/lib/http.ts
+++ b/packages/shared/http/src/lib/http.ts
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright 2023 Nelson Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function http(): string {
+  return 'http';
+}

--- a/packages/shared/http/tsconfig.json
+++ b/packages/shared/http/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/shared/http/tsconfig.lib.json
+++ b/packages/shared/http/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/shared/http/tsconfig.spec.json
+++ b/packages/shared/http/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,7 +19,8 @@
     "paths": {
       "@gelato/apis/orders": ["packages/apis/orders/src/index.ts"],
       "@gelato/apis/products": ["packages/apis/products/src/index.ts"],
-      "@gelato/apis/shipment": ["packages/apis/shipment/src/index.ts"]
+      "@gelato/apis/shipment": ["packages/apis/shipment/src/index.ts"],
+      "@gelato/shared/http": ["packages/shared/http/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,6 +3241,11 @@ domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,7 +2349,7 @@ autoprefixer@^10.4.9:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
-axios@^1.0.0:
+axios@^1.0.0, axios@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
   integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ekkolon/gelato-node/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no convenient way to make authenticated requests to Gelato APIs.

Issue Number: N/A

## What is the new behavior?
This PR introduces a new shared library `http`. It is responsible for handling requests to Gelato APIs. The library exposes an `HttpClient` constructor, allowing consumers to initialize it with an `apiKey` option to make authenticated requests. System users may also choose to provide an `GELATO_API_KEY` environment variable instead of using the _apiKey_ option. 

Further, feature API libraries can now query and mutate data without the need to repeatedly create authenticated request methods because it happens in one place, the HttpClient.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A
